### PR TITLE
Issue #12: Fix Winner number text jiggle on randomize animation.

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -188,7 +188,7 @@ ul > li > button {
 #lottery #owned {
 	float: left;
 	width: 50%;
-	text-align: center;
+	text-align: left;
 }
 #lottery #winner:before {
 	content: 'Winner number: ';


### PR DESCRIPTION
Fix the lottery 'Winner number' text jiggling during the randomized animation for the drawing of the lottery number. 